### PR TITLE
- disabled eslint "strict" for gulpfiles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -207,6 +207,7 @@
   "env": {
     "es6": true,
     "node": true,
-    "browser": true
+    "browser": true,
+    "mocha": true
   }
 }

--- a/gfiles/client-css.js
+++ b/gfiles/client-css.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const gulp = require('gulp');
 const { client } = require('./locations.js');

--- a/gfiles/client-js.js
+++ b/gfiles/client-js.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const gulp = require('gulp');
 const path = require('path');

--- a/gfiles/client-misc.js
+++ b/gfiles/client-misc.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const gulp = require('gulp');
 const changed = require('gulp-changed');

--- a/gfiles/client.js
+++ b/gfiles/client.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const gulp = require('gulp');
 const { client } = require('./locations.js');

--- a/gfiles/crawler.js
+++ b/gfiles/crawler.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const gulp = require('gulp');
 const babel = require('gulp-babel');

--- a/gfiles/locations.js
+++ b/gfiles/locations.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const client = {
   clean: 'public/',

--- a/gfiles/server.js
+++ b/gfiles/server.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const gulp = require('gulp');
 const babel = require('gulp-babel');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app/index.js",
   "scripts": {
     "test": "node_modules/.bin/nyc --require babel-core/register node_modules/.bin/mocha src/test/**/*.js",
-    "lint": "./node_modules/.bin/eslint src/js/",
+    "lint": "./node_modules/.bin/eslint gfiles/ src/js/ src/test",
     "clean": "gulp clean-all",
     "build": "gulp all",
     "clean-build": "npm run clean && npm run build",

--- a/src/test/config/index.js
+++ b/src/test/config/index.js
@@ -7,7 +7,7 @@ function getFakeNConf() {
   const fake = {};
   const markers = [];
   fake.markers = markers;
-  const makeTestFunction = function (marker) {
+  function makeTestFunction(marker) {
     return function () {
       markers.push(marker);
       return fake;
@@ -24,7 +24,7 @@ function getFakeNConf() {
   return fake;
 }
 
-describe('config', function() {
+describe('config', function () {
   describe('nconf setup', function () {
     let nconf;
     let config;


### PR DESCRIPTION
node currently doesn't support ECMAScript, and gulpfiles are not transpiled. Therefore we need the strict mode directive. Since we can't specify different sourcetype for different files, the only way to proceed is to disable the rule in each file that must have the directive.
- added "mocha" as environment in eslintrc
  now we won't have errors about mocha global not being defined.
- Fixed lint errors within test/config
- Updated "lint" script in package.json to lint gulpfiles and test files in addition to source files.