### PR TITLE
Task/no es6 modules (#25)

### DIFF
--- a/src/js/config/index.js
+++ b/src/js/config/index.js
@@ -3,9 +3,9 @@
 @description Exposes itself as a function which itself is a wrapper around nconf.get. Uses command
 line, environment, config file and defaults; in this order.
 */
-import nconf from 'nconf';
-import path from 'path';
-import getLogger from '../logger';
+const nconf = require('nconf');
+const path = require('path');
+const { getLogger } = require('../logger');
 
 
 const configFilePath = path.join(process.cwd(), 'config.json');
@@ -53,8 +53,7 @@ function config(key) {
   const result = nconf.get(key);
   if (typeof result === 'undefined')
     logger.warn(`no config value found for key: ${key}`);
-  return result; 
+  return result;
 }
 
-// usage: value = config('key')
-export default config;
+module.exports = { config };

--- a/src/js/crud/index.js
+++ b/src/js/crud/index.js
@@ -2,9 +2,9 @@
  * @module crud
  * @description What the name says.
  */
-import MongoClient from 'mongodb';
-import config from '../config';
-import getLogger from '../logger';
+const { MongoClient } = require('mongodb');
+const { config } = require('../config');
+const { getLogger } = require('../logger');
 
 
 const logger = getLogger({
@@ -17,7 +17,7 @@ const logger = getLogger({
  * Enum for group types.
  * @memberof module:model
  */
-export const GroupType = {
+const GroupType = {
   DIRECTORY: 1
 };
 
@@ -43,22 +43,18 @@ export const GroupType = {
  */
 
 
-/**
- * @constant Crud
- * @memberof module:crud
- */
-export const Crud = {
+const Crud = module.exports = {
+  GroupType: GroupType,
   isInitialised: false,
   db: null,
   collections: {},
 };
 
-export default Crud;
-
 
 /**
- * @propertyof Crud
+ * @alias CollectionName
  * @enum {String}
+ * @memberof module:crud
  * @description an enumeration of collection names.
  */
 Crud.CollectionName = {
@@ -69,6 +65,7 @@ Crud.CollectionName = {
 
 /**
  * Connects to the mongodb server and gets a db instance.
+ * @alias connect
  * @memberof module:crud
  * @returns {Promise}
  */
@@ -91,6 +88,7 @@ Crud.connect = function connect() {
 /**
  * Initialises the crud module if required. Calls connect and creates collections named in the
  * CollectionName enumeration (unless they already exist).
+ * @alias initialise
  * @memberof module:crud
  * @return {Promise}
  */
@@ -111,9 +109,10 @@ Crud.initialise = function initialise() {
 
 
 /**
- * @memberof module:crud
  * @param {Object} query - the query to get groups with. As meant for mongo db
  *   `collection.find()`.
+ * @alias getGroups
+ * @memberof module:crud
  * @returns {Promise} - A promise that resolves in an array of Group objects
  */
 Crud.getGroups = function getGroups(query = {}) {
@@ -132,6 +131,7 @@ Crud.getGroups = function getGroups(query = {}) {
 /**
  * Store groups into the DB. Will replace existing groups if found with matching ids.
  * // TODO: We should implement a strict PUT (with 409s) and DELETE
+ * @alias putGroups
  * @memberof module:crud
  * @param {Group[]} groups - the groups to be stored.
  * @returns {Promise} -  a promise that resolves with the same groups that were stored once they
@@ -152,6 +152,8 @@ Crud.putGroups = function putGroups(groups = []) {
 
 /**
  * Get an array of pictures.
+ * @alias getPictures
+ * @memberof module:crud
  * @param {Object} query
  * @returns {Promise} - A promise that resolves into an array of Picture objects.
  */
@@ -170,6 +172,8 @@ Crud.getPictures = function getPictures(query) {
 
 /**
  * Store pictures into the DB.
+ * @alias putPictures
+ * @memberof module:crud
  * @param {Picture} - The pictures to be stored.
  * @returns {Promise} -  a promise that resolves with the same pictures that were stored once they
  *   have been stored.

--- a/src/js/logger/index.js
+++ b/src/js/logger/index.js
@@ -2,9 +2,9 @@
 @module logger
 @description A logger module (built as an abstraction around winston). Exposes a getLogger function which will return a simple logger.
 */
-import winston from 'winston';
-import path from 'path';
-import fs from 'fs-extra';
+const winston = require('winston');
+const path = require('path');
+const fs = require('fs-extra');
 
 
 /**
@@ -16,14 +16,20 @@ import fs from 'fs-extra';
 */
 
 
+const Logger = module.exports = {};
+
+
 /**
+@alias _getTransports
+@memberof module:logger
+@access private
 @param {Object} opts
 @param {String} opts.level.console
 @param {String} opts.level.file
 @param {String} opts.filePath
 @return {Array} - an array of winston transports.
 */
-export function _getTransports({ filePath, level = {} }) {
+Logger._getTransports = function _getTransports({ filePath, level = {} }) {
   return [
     new winston.transports.Console({
       level: level.console,
@@ -40,19 +46,21 @@ export function _getTransports({ filePath, level = {} }) {
 
 
 /**
+@alias getLogger
+@memberof module:logger
 @param {Object} opts
 @param {String} opts.level - debugger level
 @param {String} opts.filePath
 @param {String} [opts.fileLevel] - optional level override when logging to file
 @returns {Logger}
 */
-export function getLogger(opts = {}) {
+Logger.getLogger = function getLogger(opts = {}) {
   if (!opts.filePath)
     throw new Error('log file location not provided to logger');
 
   fs.ensureDirSync(path.dirname(opts.filePath));
   const logger = new winston.Logger({
-    transports: _getTransports(opts)
+    transports: Logger._getTransports(opts)
   });
 
   /*
@@ -68,5 +76,3 @@ export function getLogger(opts = {}) {
     error: logger.error.bind(logger)
   };
 }
-
-export default getLogger;

--- a/src/js/server/index.js
+++ b/src/js/server/index.js
@@ -3,6 +3,6 @@
 @description Initialises the web-server using the Server class within this module.
 */
 
-import Server from './server.js';
-import DB from './db';
+const Server = require('./server.js');
+const DB = require('./db');
 Server.startWebServer();

--- a/src/js/server/server.js
+++ b/src/js/server/server.js
@@ -1,10 +1,10 @@
-import config from '../config';
-import getLogger from '../logger';
-import path from 'path';
-import fs from 'fs-extra';
-import express from 'express';
-import bodyParser from 'body-parser';
-import serveStatic from 'serve-static';
+const { config } = require('../config');
+const { getLogger } = require('../logger');
+const path = require('path');
+const fs = require('fs-extra');
+const express = require('express');
+const bodyParser = require('body-parser');
+const serveStatic = require('serve-static');
 
 
 const logger = getLogger({
@@ -12,16 +12,13 @@ const logger = getLogger({
   filePath: 'webserver.log.path'
 });
 
-/**
- * @constant Server
- * @memberof module:server
- * @description The webserver.
- */
-const Server = {};
+
+const Server = module.exports = {};
 
 
 /**
  * @memberof module:server
+ * @alias setUpStaticServer
  * @param {App} app
  * @returns {App} - the same app instance that was supplied as argument
  */
@@ -45,6 +42,7 @@ Server.setUpStaticServer = function(app) {
 
 /**
  * @memberof module:server
+ * @alias startWebServer
  * @description Starts the entire web-server
  */
 Server.startWebServer = function() {
@@ -61,6 +59,7 @@ Server.startWebServer = function() {
 
 /**
  * @memberof module:server
+ * @alias handleServerStart
  * @description Handle server start event. Empty for now.
  */
 Server.handleServerStart = function() {
@@ -69,4 +68,4 @@ Server.handleServerStart = function() {
 };
 
 
-export default Server;
+module.exports = Server;

--- a/test/config/index.js
+++ b/test/config/index.js
@@ -1,6 +1,5 @@
-import mockery from 'mockery';
-import getFakeNConf from '../mock/nconf';
-import chai from 'chai';
+const mockery = require('mockery');
+const chai = require('chai');
 chai.should();
 
 describe('config', function() {
@@ -14,9 +13,9 @@ describe('config', function() {
         useCleanCache: true,
         warnOnUnregistered: false
       });
-      nconf = getFakeNConf();
+      nconf = require('../mock/nconf');
       mockery.registerMock('nconf', nconf);
-      config = require('../../src/js/config').default;
+      config = require('../../src/js/config').config;
     });
 
 

--- a/test/crud/index.js
+++ b/test/crud/index.js
@@ -29,9 +29,9 @@ describe('crud', function() {
   it('tests connect should connect to the db', function() {
     const dbURL = 'D-B-U-R-L';
     const mongodb = require('../mock/mongodb');
-    const config = require('../mock/config').default;
+    const { config } = require('../mock/config');
     config.withArgs('db.url').returns(dbURL);
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     return Crud.connect()
       .then(function(result) {
         mongodb.MongoClient.connect.calledWith(dbURL);
@@ -45,9 +45,9 @@ describe('crud', function() {
   it('tests connect does not try to connect if already connected', function() {
     const dbURL = 'D-B-U-R-L';
     const mongodb = require('../mock/mongodb');
-    const config = require('../mock/config').default;
+    const { config } = require('../mock/config');
     config.withArgs('db.url').returns(dbURL);
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     Crud.db = 'foo';
     return Crud.connect()
       .then(function(result) {
@@ -62,7 +62,7 @@ describe('crud', function() {
     // should create db collections for all the items named in the collections enum
     const mongodb = require('../mock/mongodb');
     const db = mongodb.db;
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     db.collection.returns(Promise.resolve('-a-collection-'));
     Crud.connect = sinon.stub();
     Crud.connect.returns(Promise.resolve(db));
@@ -80,7 +80,7 @@ describe('crud', function() {
 
   it('tests initialise does not call connect if already initialised', function() {
     const mongodb = require('../mock/mongodb');
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     Crud.isInitialised = true;
     Crud.connect = sinon.stub();
     Crud.connect.returns(Promise.resolve('bar'));
@@ -96,7 +96,7 @@ describe('crud', function() {
 
 
   it('tests getGroups', function() {
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     Crud.initialise = sinon.stub();
     Crud.initialise.returns(Promise.resolve());
     const {
@@ -116,7 +116,7 @@ describe('crud', function() {
 
 
   it('tests putGroups', function() {
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     Crud.initialise = sinon.stub();
     Crud.initialise.returns(Promise.resolve());
     const { collection } = require('../mock/mongodb');
@@ -136,7 +136,7 @@ describe('crud', function() {
 
 
   it('tests getPictures', function() {
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     Crud.initialise = sinon.stub();
     Crud.initialise.returns(Promise.resolve());
     const {
@@ -156,7 +156,7 @@ describe('crud', function() {
 
 
   it('tests putPictures', function() {
-    const Crud = require(crudModulePath).default;
+    const Crud = require(crudModulePath);
     Crud.initialise = sinon.stub();
     Crud.initialise.returns(Promise.resolve());
     const { collection } = require('../mock/mongodb');

--- a/test/logger/index.js
+++ b/test/logger/index.js
@@ -24,12 +24,6 @@ describe('logger', function() {
 
 
   describe('getLogger', function() {
-    it('tests that logger.getLogger is a function', function() {
-      loggerModule.getLogger.should.be.a('function');
-      loggerModule.default.should.be.a('function');
-    });
-
-
     it('tests that getLogger throws an error when not given opts.filePath', function() {
       loggerModule.getLogger.should.throw(/log file location not provided to logger/);
     });

--- a/test/mock/body-parser.js
+++ b/test/mock/body-parser.js
@@ -9,4 +9,4 @@ const bodyParser = {
 };
 
 
-export default bodyParser;
+module.exports = bodyParser;

--- a/test/mock/config.js
+++ b/test/mock/config.js
@@ -2,4 +2,4 @@ import sinon from 'sinon';
 
 
 const config = sinon.stub();
-export default config;
+module.exports = { config };

--- a/test/mock/express.js
+++ b/test/mock/express.js
@@ -12,4 +12,4 @@ const app = {
 const express = sinon.stub();
 express.returns(app);
 
-export default express;
+module.exports = express;

--- a/test/mock/fs-extra.js
+++ b/test/mock/fs-extra.js
@@ -9,4 +9,4 @@ fs.reset = function reset() {
   fs.ensureDirSync.reset();
 };
 
-export default fs;
+module.exports = fs;

--- a/test/mock/logger.js
+++ b/test/mock/logger.js
@@ -19,4 +19,4 @@ function getLogger() {
   return logger;
 }
 
-export default getLogger;
+module.exports  = { getLogger };

--- a/test/mock/mongodb.js
+++ b/test/mock/mongodb.js
@@ -1,21 +1,21 @@
 import sinon from 'sinon';
 
-export const db = {
+const db = {
   collection: sinon.stub()
 };
 db.collection.returns(Promise.resolve('foo'));
 
 
-export const connect = sinon.stub();
+const connect = sinon.stub();
 connect.returns(Promise.resolve(db));
 
 
-export const MongoClient = {
+const MongoClient = {
   connect
 };
 
 
-export function collection(findResult) {
+function collection(findResult) {
   const find = sinon.stub();
   find.returns(findResult);
 
@@ -28,11 +28,17 @@ export function collection(findResult) {
 }
 
 
-export function findResult(toArrayResult) {
+function findResult(toArrayResult) {
   const toArray = () => Promise.resolve(toArrayResult);
   return {
     toArray
   };
 }
 
-export default MongoClient;
+module.exports = {
+  MongoClient,
+  db,
+  connect,
+  collection,
+  findResult
+};

--- a/test/mock/nconf.js
+++ b/test/mock/nconf.js
@@ -26,4 +26,4 @@ function getFakeNConf() {
 }
 
 
-export default getFakeNConf;
+module.exports = getFakeNConf();

--- a/test/mock/serve-static.js
+++ b/test/mock/serve-static.js
@@ -9,4 +9,4 @@ function getServeStatic() {
 const serveStatic = getServeStatic();
 
 
-export default serveStatic;
+module.exports = serveStatic;

--- a/test/mock/winston.js
+++ b/test/mock/winston.js
@@ -16,4 +16,4 @@ const winston = {
 };
 
 
-export default winston;
+module.exports = winston;

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -1,6 +1,6 @@
-import mockery from 'mockery';
-import sinon from 'sinon';
-import chai from 'chai';
+const mockery = require('mockery');
+const sinon = require('sinon');
+const chai = require('chai');
 chai.should();
 
 
@@ -35,10 +35,10 @@ describe('server', function() {
       const ssThumbnailDirPath = 'SS_THUMBNAILDIRPATH';
       const imagePreviewPath = 'IMAGEPREVIEWPATH';
       const ssImagePreviewPath = 'SS_IMAGEPREVIEWPATH';
-      const config = require('../mock/config').default;
-      const fs = require('../mock/fs-extra').default;
-      const express = require('../mock/express').default;
-      const serveStatic = require('../mock/serve-static.js').default;
+      const { config } = require('../mock/config');
+      const fs = require('../mock/fs-extra');
+      const express = require('../mock/express');
+      const serveStatic = require('../mock/serve-static.js');
       config.withArgs('webserver.root.path').returns(webRootPath);
       config.withArgs('app.thumbnail.path').returns(thumbnailDirPath);
       config.withArgs('app.imagePreview.path').returns(imagePreviewPath);
@@ -46,7 +46,7 @@ describe('server', function() {
       serveStatic.withArgs(thumbnailDirPath).returns(ssThumbnailDirPath);
       serveStatic.withArgs(imagePreviewPath).returns(ssImagePreviewPath);
       const app = express();
-      const Server = require('../../src/js/server/server.js').default;
+      const Server = require('../../src/js/server/server.js');
       Server.setUpStaticServer(app).should.equal(app);
 
       fs.ensureDirSync.callCount.should.equal(3);
@@ -70,10 +70,10 @@ describe('server', function() {
   describe('startWebServer()', function() {
     it('should call startWebServer, use bodyParser and listen on configured port', function() {
       const jsonParser = 'JSON-PARSER';
-      const express = require('../mock/express').default;
-      const bodyParser = require('../mock/body-parser.js').default;
-      const Server = require('../../src/js/server/server.js').default;
-      const config = require('../mock/config').default;
+      const express = require('../mock/express');
+      const bodyParser = require('../mock/body-parser.js');
+      const Server = require('../../src/js/server/server.js');
+      const { config } = require('../mock/config');
       const listenPort = 'WEBSERVER.PORT';
       Server.setUpStaticServer = sinon.stub();
       bodyParser.json.returns(jsonParser);


### PR DESCRIPTION
ES6 modules style may be the future, but in the present it provides advantage over node modules that I'm aware of. It makes unit testing very hard by making mocking of functions used within a module essentially impossible (not to mention it introduces new syntax and keywords to the language but that is another debate altogether).

I have been using a workaround, where I place all my functions on a constant (a stand-in for module.exports) and only define and use functions with the qualified name; But this is simply because code is transpiled today; I don't know if this will continue working when we have native es2015 modules. Finally, const { foo } = require('bar'); is much closer to reality than import foo from 'bar';.

This commit replaces all the import / export statements with good old require and module.exports. (If I really need to, I can always change it in the future).